### PR TITLE
pgx.ErrNoRows and sql.ErrNoRows

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
-github.com/cockroachdb/cockroach-go/v2 v2.0.2 h1:3ZK+zM18axuS2y/1Gmc1DLKD2b2SYjvpAuVdz4lJlcw=
-github.com/cockroachdb/cockroach-go/v2 v2.0.2/go.mod h1:hAuDgiVgDVkfirP9JnhXEfcXEPRKBpYdGz+l7mvYSzw=
 github.com/cockroachdb/cockroach-go/v2 v2.0.3 h1:ZA346ACHIZctef6trOTwBAEvPVm1k0uLm/bb2Atc+S8=
 github.com/cockroachdb/cockroach-go/v2 v2.0.3/go.mod h1:hAuDgiVgDVkfirP9JnhXEfcXEPRKBpYdGz+l7mvYSzw=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/pgxscan/pgxscan.go
+++ b/pgxscan/pgxscan.go
@@ -55,12 +55,18 @@ func ScanAll(dst interface{}, rows pgx.Rows) error {
 // See dbscan.ScanOne for details.
 func ScanOne(dst interface{}, rows pgx.Rows) error {
 	err := dbscan.ScanOne(dst, NewRowsAdapter(rows))
+	if NotFound(err) {
+		return errors.WithStack(pgx.ErrNoRows)
+	}
 	return errors.WithStack(err)
 }
 
 // NotFound is a wrapper around the dbscan.NotFound function.
 // See dbscan.NotFound for details.
 func NotFound(err error) bool {
+	if errors.Is(err, pgx.ErrNoRows) {
+		return true
+	}
 	return dbscan.NotFound(err)
 }
 

--- a/pgxscan/pgxscan.go
+++ b/pgxscan/pgxscan.go
@@ -52,8 +52,8 @@ func ScanAll(dst interface{}, rows pgx.Rows) error {
 }
 
 // ScanOne is a wrapper around the dbscan.ScanOne function.
-// See dbscan.ScanOne for details. If no rows are found we
-// return a `pgx.ErrNoRows` error, otherwise nil.
+// See dbscan.ScanOne for details. If no rows are found it
+// returns a pgx.ErrNoRows error.
 func ScanOne(dst interface{}, rows pgx.Rows) error {
 	err := dbscan.ScanOne(dst, NewRowsAdapter(rows))
 	if dbscan.NotFound(err) {

--- a/pgxscan/pgxscan.go
+++ b/pgxscan/pgxscan.go
@@ -52,22 +52,20 @@ func ScanAll(dst interface{}, rows pgx.Rows) error {
 }
 
 // ScanOne is a wrapper around the dbscan.ScanOne function.
-// See dbscan.ScanOne for details.
+// See dbscan.ScanOne for details. If no rows are found we
+// return a `pgx.ErrNoRows` error, otherwise nil.
 func ScanOne(dst interface{}, rows pgx.Rows) error {
 	err := dbscan.ScanOne(dst, NewRowsAdapter(rows))
-	if NotFound(err) {
+	if dbscan.NotFound(err) {
 		return errors.WithStack(pgx.ErrNoRows)
 	}
 	return errors.WithStack(err)
 }
 
-// NotFound is a wrapper around the dbscan.NotFound function.
-// See dbscan.NotFound for details.
+// NotFound is a helper function to check if an error
+// is `pgx.ErrNoRows`.
 func NotFound(err error) bool {
-	if errors.Is(err, pgx.ErrNoRows) {
-		return true
-	}
-	return dbscan.NotFound(err)
+	return errors.Is(err, pgx.ErrNoRows)
 }
 
 // RowScanner is a wrapper around the dbscan.RowScanner type.

--- a/pgxscan/pgxscan_test.go
+++ b/pgxscan/pgxscan_test.go
@@ -37,6 +37,9 @@ const (
 	singleRowsQuery = `
 		SELECT 'foo val' AS foo, 'bar val' AS bar
 	`
+	noRowsQuery = `
+		SELECT NULL AS foo, NULL AS bar LIMIT 0;
+    `
 )
 
 func TestSelect(t *testing.T) {
@@ -96,11 +99,8 @@ func TestGet_queryError_propagatesAndWrapsErr(t *testing.T) {
 
 func TestGet_noRows_returnsNotFoundErr(t *testing.T) {
 	t.Parallel()
-	query := `
-		SELECT NULL AS foo, NULL AS bar LIMIT 0;
-	`
 	var got testModel
-	err := pgxscan.Get(ctx, testDB, &got, query)
+	err := pgxscan.Get(ctx, testDB, &got, noRowsQuery)
 
 	assert.True(t, pgxscan.NotFound(err))
 	assert.True(t, errors.Is(err, pgx.ErrNoRows))
@@ -139,10 +139,7 @@ func TestScanOne(t *testing.T) {
 
 func TestScanOne_noRows_returnsNotFoundErr(t *testing.T) {
 	t.Parallel()
-	query := `
-		SELECT NULL AS foo, NULL AS bar LIMIT 0;
-	`
-	rows, err := testDB.Query(ctx, query)
+	rows, err := testDB.Query(ctx, noRowsQuery)
 	require.NoError(t, err)
 
 	var got testModel

--- a/pgxscan/pgxscan_test.go
+++ b/pgxscan/pgxscan_test.go
@@ -97,16 +97,6 @@ func TestGet_queryError_propagatesAndWrapsErr(t *testing.T) {
 	assert.EqualError(t, err, expectedErr)
 }
 
-func TestGet_noRows_returnsNotFoundErr(t *testing.T) {
-	t.Parallel()
-	var got testModel
-	err := pgxscan.Get(ctx, testDB, &got, noRowsQuery)
-
-	assert.True(t, pgxscan.NotFound(err))
-	assert.True(t, errors.Is(err, pgx.ErrNoRows))
-	assert.True(t, stderrors.Is(err, pgx.ErrNoRows))
-}
-
 func TestScanAll(t *testing.T) {
 	t.Parallel()
 	expected := []*testModel{

--- a/sqlscan/sqlscan.go
+++ b/sqlscan/sqlscan.go
@@ -51,22 +51,20 @@ func ScanAll(dst interface{}, rows *sql.Rows) error {
 }
 
 // ScanOne is a wrapper around the dbscan.ScanOne function.
-// See dbscan.ScanOne for details.
+// See dbscan.ScanOne for details. If no rows are found we
+// return an `sql.ErrNoRows` error, otherwise nil.
 func ScanOne(dst interface{}, rows *sql.Rows) error {
 	err := dbscan.ScanOne(dst, rows)
-	if NotFound(err) {
+	if dbscan.NotFound(err) {
 		return errors.WithStack(sql.ErrNoRows)
 	}
 	return errors.WithStack(err)
 }
 
-// NotFound is a wrapper around the dbscan.NotFound function.
-// See dbscan.NotFound for details.
+// NotFound is a helper function to check if an error
+// is `sql.ErrNoRows`.
 func NotFound(err error) bool {
-	if errors.Is(err, sql.ErrNoRows) {
-		return true
-	}
-	return dbscan.NotFound(err)
+	return errors.Is(err, sql.ErrNoRows)
 }
 
 // RowScanner is a wrapper around the dbscan.RowScanner type.

--- a/sqlscan/sqlscan.go
+++ b/sqlscan/sqlscan.go
@@ -51,8 +51,8 @@ func ScanAll(dst interface{}, rows *sql.Rows) error {
 }
 
 // ScanOne is a wrapper around the dbscan.ScanOne function.
-// See dbscan.ScanOne for details. If no rows are found we
-// return an `sql.ErrNoRows` error, otherwise nil.
+// See dbscan.ScanOne for details. If no rows are found it
+// returns an sql.ErrNoRows error.
 func ScanOne(dst interface{}, rows *sql.Rows) error {
 	err := dbscan.ScanOne(dst, rows)
 	if dbscan.NotFound(err) {

--- a/sqlscan/sqlscan.go
+++ b/sqlscan/sqlscan.go
@@ -54,12 +54,18 @@ func ScanAll(dst interface{}, rows *sql.Rows) error {
 // See dbscan.ScanOne for details.
 func ScanOne(dst interface{}, rows *sql.Rows) error {
 	err := dbscan.ScanOne(dst, rows)
+	if NotFound(err) {
+		return errors.WithStack(sql.ErrNoRows)
+	}
 	return errors.WithStack(err)
 }
 
 // NotFound is a wrapper around the dbscan.NotFound function.
 // See dbscan.NotFound for details.
 func NotFound(err error) bool {
+	if errors.Is(err, sql.ErrNoRows) {
+		return true
+	}
 	return dbscan.NotFound(err)
 }
 

--- a/sqlscan/sqlscan_test.go
+++ b/sqlscan/sqlscan_test.go
@@ -37,6 +37,9 @@ const (
 	singleRowsQuery = `
 		SELECT 'foo val' AS foo, 'bar val' AS bar
 	`
+	noRowsQuery = `
+		SELECT NULL AS foo, NULL AS bar LIMIT 0;
+    `
 )
 
 func TestSelect(t *testing.T) {
@@ -96,11 +99,8 @@ func TestGet_queryError_propagatesAndWrapsErr(t *testing.T) {
 
 func TestGet_noRows_returnsNotFoundErr(t *testing.T) {
 	t.Parallel()
-	query := `
-		SELECT NULL AS foo, NULL AS bar LIMIT 0;
-	`
 	var got testModel
-	err := sqlscan.Get(ctx, testDB, &got, query)
+	err := sqlscan.Get(ctx, testDB, &got, noRowsQuery)
 
 	assert.True(t, sqlscan.NotFound(err))
 	assert.True(t, errors.Is(err, sql.ErrNoRows))
@@ -139,10 +139,7 @@ func TestScanOne(t *testing.T) {
 
 func TestScanOne_noRows_returnsNotFoundErr(t *testing.T) {
 	t.Parallel()
-	query := `
-		SELECT NULL AS foo, NULL AS bar LIMIT 0;
-	`
-	rows, err := testDB.Query(query)
+	rows, err := testDB.Query(noRowsQuery)
 	require.NoError(t, err)
 
 	var got testModel

--- a/sqlscan/sqlscan_test.go
+++ b/sqlscan/sqlscan_test.go
@@ -97,16 +97,6 @@ func TestGet_queryError_propagatesAndWrapsErr(t *testing.T) {
 	assert.EqualError(t, err, expectedErr)
 }
 
-func TestGet_noRows_returnsNotFoundErr(t *testing.T) {
-	t.Parallel()
-	var got testModel
-	err := sqlscan.Get(ctx, testDB, &got, noRowsQuery)
-
-	assert.True(t, sqlscan.NotFound(err))
-	assert.True(t, errors.Is(err, sql.ErrNoRows))
-	assert.True(t, stderrors.Is(err, sql.ErrNoRows))
-}
-
 func TestScanAll(t *testing.T) {
 	t.Parallel()
 	expected := []*testModel{


### PR DESCRIPTION
From the discussion in #13 this returns `pgx.ErrNoRows` and `sql.ErrNoRows` for both `ScanOne` and `Get`.

In addition a check in the `NotFound` function is added to maintain backwards compatibility with any existing code.