### PR TITLE
Support nested structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Secondly, it doesn't know anything about relations between objects e.g: one to m
 ## Features
 
 * Custom database column name via struct tag
-* Embedded structs 
+* Reusing structs via nesting or embedding 
 * NULLs and custom types support
 * Omitted struct fields
 * Apart from structs, support for other destination types: maps, slices and etc.

--- a/dbscan/doc.go
+++ b/dbscan/doc.go
@@ -33,7 +33,7 @@ dbscan works recursively, a struct can contain embedded or nested structs as wel
 It allows reusing models in different queries. Structs can be embedded or nested both by value and by a pointer.
 If you don't specify the `db` tag, dbscan maps fields from nested structs to database columns
 with the struct field name translated to snake case as the prefix,
-on the opposite, fields from embedded structs are mapped to database column without any prefix.
+on the opposite, fields from embedded structs are mapped to database columns without any prefix.
 dbscan uses "." to separate the prefix. Here is an example:
 
 	type UserPost struct {

--- a/dbscan/rowscanner_test.go
+++ b/dbscan/rowscanner_test.go
@@ -18,7 +18,7 @@ type BarNested struct {
 	BarNested string
 }
 
-type JsonObj struct {
+type JSONObj struct {
 	Key string
 }
 
@@ -334,10 +334,10 @@ func TestRowScanner_Scan_structDestination(t *testing.T) {
 				SELECT '{"key": "key val"}'::JSON AS foo_json, 'foo val' AS foo
 			`,
 			expected: struct {
-				FooJSON JsonObj
+				FooJSON JSONObj
 				Foo     string
 			}{
-				FooJSON: JsonObj{Key: "key val"},
+				FooJSON: JSONObj{Key: "key val"},
 				Foo:     "foo val",
 			},
 		},
@@ -347,10 +347,10 @@ func TestRowScanner_Scan_structDestination(t *testing.T) {
 				SELECT '{"key": "key val"}'::JSON AS foo_json, 'foo val' AS foo
 			`,
 			expected: struct {
-				FooJSON *JsonObj
+				FooJSON *JSONObj
 				Foo     string
 			}{
-				FooJSON: &JsonObj{Key: "key val"},
+				FooJSON: &JSONObj{Key: "key val"},
 				Foo:     "foo val",
 			},
 		},
@@ -517,11 +517,11 @@ func TestRowScanner_Scan_invalidStructDestination_returnsErr(t *testing.T) {
 				SELECT '{"key": "key val"}'::JSON AS foo_json, 'foo val' AS foo
 			`,
 			dst: &struct {
-				JsonObj `db:"foo_json"`
+				JSONObj `db:"foo_json"`
 				Foo     string
 			}{},
 			expectedErr: "scany: column: 'foo_json': no corresponding field found, " +
-				"or it's unexported in struct { dbscan_test.JsonObj \"db:\\\"foo_json\\\"\"; Foo string }",
+				"or it's unexported in struct { dbscan_test.JSONObj \"db:\\\"foo_json\\\"\"; Foo string }",
 		},
 	}
 	for _, tc := range cases {
@@ -577,7 +577,7 @@ func TestRowScanner_Scan_mapDestination(t *testing.T) {
 			query: `
 				SELECT '{"key": "key val"}'::JSON AS foo_json, '{"key": "key val 2"}'::JSON AS bar_json
 			`,
-			expected: map[string]JsonObj{
+			expected: map[string]JSONObj{
 				"foo_json": {Key: "key val"},
 				"bar_json": {Key: "key val 2"},
 			},
@@ -587,7 +587,7 @@ func TestRowScanner_Scan_mapDestination(t *testing.T) {
 			query: `
 				SELECT '{"key": "key val"}'::JSON AS foo_json, NULL AS bar_json
 			`,
-			expected: map[string]*JsonObj{
+			expected: map[string]*JSONObj{
 				"foo_json": {Key: "key val"},
 				"bar_json": nil,
 			},
@@ -701,7 +701,7 @@ func TestRowScanner_Scan_primitiveTypeDestination(t *testing.T) {
 				SELECT '{"key": "key val"}'::JSON AS foo_json
 			`,
 
-			expected: &JsonObj{Key: "key val"},
+			expected: &JSONObj{Key: "key val"},
 		},
 		{
 			name: "map by ptr treated as primitive type",

--- a/dbscan/rowscanner_test.go
+++ b/dbscan/rowscanner_test.go
@@ -139,7 +139,7 @@ func TestRowScanner_Scan_structDestination(t *testing.T) {
 			},
 		},
 		{
-			name: "embedded struct with tag is filled from columns with prefix",
+			name: "embedded struct with tag is filled from columns with prefix from the tag",
 			query: `
 				SELECT 'foo val' AS foo, 'bar val' AS bar,
 					'foo nested val' as "foo_nested.foo_nested"
@@ -157,7 +157,7 @@ func TestRowScanner_Scan_structDestination(t *testing.T) {
 			},
 		},
 		{
-			name: "nested struct with tag is filled from columns with prefix",
+			name: "nested struct with tag is filled from columns with prefix from the tag",
 			query: `
 				SELECT 'foo val' AS foo, 'bar val' AS bar,
 					'foo nested val' as "foo_nested_prefix.foo_nested"


### PR DESCRIPTION
As discussed in https://github.com/georgysavva/scany/issues/17 this adds support for nested structs to mirror the sqlx feature. Also as a side change now it's allowed to embed unexported structs 