### PR TITLE
fields: add function to return expression for selecting all columns of a given struct.

### DIFF
--- a/internal/structref/structref_test.go
+++ b/internal/structref/structref_test.go
@@ -1,0 +1,98 @@
+package structref
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestGetColumnToFieldIndexMap(t *testing.T) {
+	type NestedTheme struct {
+		ID   string
+		Name string
+	}
+	type Embed struct {
+		Play bool
+	}
+	tests := []struct {
+		name string
+		v    interface{}
+		want map[string][]int
+	}{
+		{
+			name: "empty",
+			v:    struct{}{},
+			want: map[string][]int{},
+		},
+		{
+			name: "unexported",
+			v: struct {
+				unexported string
+			}{},
+			want: map[string][]int{},
+		},
+		{
+			name: "one",
+			v: struct {
+				One string
+			}{},
+			want: map[string][]int{"one": {0}},
+		},
+		{
+			name: "multiple",
+			v: struct {
+				ID          string
+				Name        string
+				Code        string
+				IsActive    bool
+				Theme       NestedTheme       `db:"theme,json"`
+				Alternative NestedTheme       `db:"alternative,other,json"`
+				Map         map[string]string `db:"jm"`
+				CreatedAt   time.Time
+				ModifiedAt  time.Time
+				Ignored     string `db:"-"`
+				Pointer     *string
+				Embed
+			}{},
+			want: map[string][]int{
+				"id":          {0},
+				"name":        {1},
+				"code":        {2},
+				"is_active":   {3},
+				"theme":       {4},
+				"alternative": {5},
+				"jm":          {6},
+				"created_at":  {7},
+				"modified_at": {8},
+				"pointer":     {10},
+				"play":        {11, 0},
+			},
+		},
+		{
+			name: "no_json_tag_option",
+			v: struct {
+				ID          string
+				Alternative NestedTheme `db:"renamed,nope"`
+			}{},
+			want: map[string][]int{
+				"id":           {0},
+				"renamed":      {1},
+				"renamed.id":   {1, 0},
+				"renamed.name": {1, 1},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			structType := reflect.Indirect(reflect.ValueOf(tt.v)).Type()
+			if got := GetColumnToFieldIndexMap(structType); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetColumnToFieldIndexMap() = %v, want %v", got, tt.want)
+			}
+
+			// Run again to check cached values:
+			if got := GetColumnToFieldIndexMap(structType); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetColumnToFieldIndexMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/structref/tags.go
+++ b/internal/structref/tags.go
@@ -1,0 +1,44 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file of the Go project.
+
+package structref
+
+import (
+	"strings"
+)
+
+// tagOptions is the string following a comma in a struct field's "json"
+// tag, or the empty string. It does not include the leading comma.
+type tagOptions string
+
+// parseTag splits a struct field's json tag into its name and
+// comma-separated options.
+func parseTag(tag string) (string, tagOptions) {
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx], tagOptions(tag[idx+1:])
+	}
+	return tag, tagOptions("")
+}
+
+// Contains reports whether a comma-separated list of options
+// contains a particular substr flag. substr must be surrounded by a
+// string boundary or commas.
+func (o tagOptions) Contains(optionName string) bool {
+	if len(o) == 0 {
+		return false
+	}
+	s := string(o)
+	for s != "" {
+		var next string
+		i := strings.Index(s, ",")
+		if i >= 0 {
+			s, next = s[:i], s[i+1:]
+		}
+		if s == optionName {
+			return true
+		}
+		s = next
+	}
+	return false
+}

--- a/scany.go
+++ b/scany.go
@@ -57,7 +57,15 @@ func Wildcard(v interface{}) string {
 
 // Fields returns column names for a SQL table that can be queried by a given Go struct.
 func Fields(v interface{}) []string {
-	rv := reflect.Indirect(reflect.ValueOf(v)).Type()
+	if v == nil {
+		return nil
+	}
+	var rv reflect.Type
+	if reflect.TypeOf(v).Kind() == reflect.Ptr {
+		rv = reflect.TypeOf(v).Elem()
+	} else {
+		rv = reflect.Indirect(reflect.ValueOf(v)).Type()
+	}
 	type column struct {
 		indices []int
 		name    string

--- a/scany.go
+++ b/scany.go
@@ -1,0 +1,98 @@
+package scany
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/georgysavva/scany/internal/structref"
+)
+
+// Wildcard returns an expression for populating a given Go struct
+// after querying a SQL database.
+//
+// For example, for the following struct it should return "name", "age"
+// type Pet struct {
+// 	Name string
+// 	Age int
+// }
+//
+// This ensures scany keeps working if you add a field to your tables,
+// making migrations easier.
+// It also has the additional benefit of only requesting data that is
+// used on your structs, instead of getting all columns with "SELECT *".
+//
+// The "db" key in the struct field's tag can specify the "json" option
+// when a JSON or JSONB data type is used.
+func Wildcard(v interface{}) string {
+	elems := Fields(v)
+	// Logic below based on strings.Join.
+	if len(elems) == 0 {
+		return ""
+	}
+	n := len(",") * (len(elems) - 1)
+	for i := 0; i < len(elems); i++ {
+		n += len(elems[i])
+	}
+
+	var b strings.Builder
+	b.Grow(n)
+	for n, s := range elems {
+		if n != 0 {
+			b.WriteString(`,`)
+		}
+		b.WriteString(`"`)
+		b.WriteString(s)
+		b.WriteString(`"`)
+		// Alias any field containing a dot to avoid output column ambiguity,
+		// as required by scany to handle nested structs.
+		if strings.ContainsRune(s, '.') {
+			b.WriteString(` as "`)
+			b.WriteString(s)
+			b.WriteString(`"`)
+		}
+	}
+	return b.String()
+}
+
+// Fields returns column names for a SQL table that can be queried by a given Go struct.
+func Fields(v interface{}) []string {
+	rv := reflect.Indirect(reflect.ValueOf(v)).Type()
+	type column struct {
+		indices []int
+		name    string
+	}
+
+	var cs []column
+	for name, i := range structref.GetColumnToFieldIndexMap(rv) {
+		cs = append(cs, column{
+			indices: i,
+			name:    name,
+		})
+	}
+	// Sort output respecting structs ordering.
+	sort.SliceStable(cs, func(i, j int) bool {
+		a, b := cs[i].indices, cs[j].indices
+		// Go inwards each nested field until the end:
+		// indices a and b represent the path to the left and right fields being sorted.
+		for {
+			switch {
+			case len(a) == 0:
+				return false
+			case len(b) == 0:
+				return true
+			case a[0] < b[0]:
+				return true
+			case a[0] > b[0]:
+				return false
+			}
+			a, b = a[1:], b[1:]
+		}
+	})
+
+	var columns []string
+	for _, column := range cs {
+		columns = append(columns, column.name)
+	}
+	return columns
+}

--- a/scany_test.go
+++ b/scany_test.go
@@ -85,6 +85,7 @@ type NestedMock struct {
 
 func TestWildcard(t *testing.T) {
 	t.Parallel()
+	var uninitializedPointer *jsonMock
 	testCases := []struct {
 		v    interface{}
 		desc string
@@ -196,6 +197,16 @@ func TestWildcard(t *testing.T) {
 			v:    &jsonMock{},
 			desc: "json",
 			want: `"id","name","code","is_active","theme","created_at","modified_at"`,
+		},
+		{
+			v:    uninitializedPointer,
+			desc: "uninitializedPointer",
+			want: `"id","name","code","is_active","theme","created_at","modified_at"`,
+		},
+		{
+			v:    nil,
+			desc: "nil",
+			want: "",
 		},
 		{
 			v:    &HasNestedMock{},

--- a/scany_test.go
+++ b/scany_test.go
@@ -1,0 +1,238 @@
+package scany // nolint: testpackage
+
+import (
+	"testing"
+	"time"
+)
+
+type mock struct {
+	Automatic string
+	Tagged    string `db:"tagged"`
+	OneTwo    string // OneTwo should be one_two in the database.
+	CamelCase string `db:"CamelCase"` // CamelCase should not be normalized to camel_case.
+	Ignored   string `db:"-"`
+}
+
+type embedMock struct {
+	Before int
+	mock
+	After string
+}
+
+type numericMock struct {
+	Number int
+}
+
+type simpleMultiEmbedMock struct {
+	mock
+	numericMock
+}
+
+type multiEmbedMock struct {
+	A string
+	mock
+	B string
+	numericMock
+	C string
+}
+
+type emptyEmbed struct{}
+
+type nameMock struct {
+	emptyEmbed //nolint: unused
+	Name       string
+}
+
+type jsonMock struct {
+	ID         string
+	Name       string
+	Code       string
+	IsActive   bool
+	Theme      NestedMock `db:"theme,json"`
+	CreatedAt  time.Time
+	ModifiedAt time.Time
+}
+
+type HasNestedMock struct {
+	ID         string
+	Name       string
+	Code       string
+	IsActive   bool
+	Theme      NestedMock
+	CreatedAt  time.Time
+	ModifiedAt time.Time
+}
+
+type HasPointerNestedMock struct {
+	ID         string
+	Name       string
+	Code       string
+	IsActive   bool
+	Theme      *NestedMock
+	CreatedAt  time.Time
+	ModifiedAt time.Time
+}
+
+type NestedMock struct {
+	PrimaryColor   string
+	SecondaryColor string
+	TextColor      string
+	TextUppercase  bool
+	SourceHeadings string
+	SourceBody     string
+	SourceDefault  string
+}
+
+func TestWildcard(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		v    interface{}
+		desc string
+		want string
+	}{
+		{
+			v:    emptyEmbed{},
+			desc: "empty",
+		},
+		{
+			v: struct {
+				unexported int
+			}{},
+			desc: "unexported",
+			want: "",
+		},
+		{
+			v: &struct {
+				unexported int
+			}{},
+			desc: "unexported pointer",
+			want: "",
+		},
+		{
+			v: struct {
+				One int
+			}{},
+			desc: "single",
+			want: `"one"`,
+		},
+		{
+			v: &struct {
+				One int
+			}{},
+			desc: "pointer single",
+			want: `"one"`,
+		},
+		{
+			v: mock{
+				Automatic: "auto string",
+				Tagged:    "tag string",
+			},
+			desc: "mock",
+			want: `"automatic","tagged","one_two","CamelCase"`,
+		},
+		{
+			v: mock{
+				Automatic: "auto string",
+				Tagged:    "tag string",
+			},
+			desc: "cached",
+			want: `"automatic","tagged","one_two","CamelCase"`,
+		},
+		{
+			v: struct {
+				Automatic string
+				Tagged    string `db:"tagged"`
+				OneTwo    string // OneTwo should be one_two in the database.
+				CamelCase string `db:"CamelCase"` // CamelCase should not be normalized to camel_case.
+				Ignored   string `db:"-"`
+			}{},
+			desc: "anonymous",
+			want: `"automatic","tagged","one_two","CamelCase"`,
+		},
+		{
+			v: struct {
+				Automatic  string
+				Tagged     string `db:"tagged"`
+				OneTwo     string // OneTwo should be one_two in the database.
+				CamelCase  string `db:"CamelCase"` // CamelCase should not be normalized to camel_case.
+				Ignored    string `db:"-"`
+				Copy       string
+				Duplicated string `db:"copy"`
+			}{},
+			desc: "duplicated",
+			want: `"automatic","tagged","one_two","CamelCase","copy"`,
+		},
+		{
+			v:    embedMock{},
+			desc: "embed",
+			want: `"before","automatic","tagged","one_two","CamelCase","after"`,
+		},
+		{
+			v:    numericMock{},
+			desc: "numeric",
+			want: `"number"`,
+		},
+		{
+			v:    simpleMultiEmbedMock{},
+			desc: "multisimpleembed",
+			want: `"automatic","tagged","one_two","CamelCase","number"`,
+		},
+		{
+			v:    multiEmbedMock{},
+			desc: "multiembed",
+			want: `"a","automatic","tagged","one_two","CamelCase","b","number","c"`,
+		},
+		{
+			v:    &mock{},
+			desc: "pointer",
+			want: `"automatic","tagged","one_two","CamelCase"`,
+		},
+		{
+			v:    &nameMock{},
+			desc: "namemock",
+			want: `"name"`,
+		},
+		{
+			v:    &jsonMock{},
+			desc: "json",
+			want: `"id","name","code","is_active","theme","created_at","modified_at"`,
+		},
+		{
+			v:    &HasNestedMock{},
+			desc: "HasNestedMock",
+			want: `"id","name","code","is_active","theme.primary_color" as "theme.primary_color","theme.secondary_color" as "theme.secondary_color","theme.text_color" as "theme.text_color","theme.text_uppercase" as "theme.text_uppercase","theme.source_headings" as "theme.source_headings","theme.source_body" as "theme.source_body","theme.source_default" as "theme.source_default","theme","created_at","modified_at"`, // nolint: lll
+		},
+		{
+			v:    &HasPointerNestedMock{},
+			desc: "HasNestedMock",
+			want: `"id","name","code","is_active","theme.primary_color" as "theme.primary_color","theme.secondary_color" as "theme.secondary_color","theme.text_color" as "theme.text_color","theme.text_uppercase" as "theme.text_uppercase","theme.source_headings" as "theme.source_headings","theme.source_body" as "theme.source_body","theme.source_default" as "theme.source_default","theme","created_at","modified_at"`, // nolint: lll
+		},
+		{
+			// Testing an edge case:
+			// Regular fields containing dots are aliased even when unnecessary, and this should be okay.
+			// This is a conscious design decision to reduce complexity avoiding leaking internal details from
+			// internal/structref through the fields() function.
+			v: struct {
+				RegularFieldWithDots string `db:"regular.field.with.dots"`
+			}{},
+			desc: "RegularFieldWithDots",
+			want: `"regular.field.with.dots" as "regular.field.with.dots"`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if got := Wildcard(tc.v); tc.want != got {
+				t.Errorf("expected expression to be %v, got %v instead", tc.want, got)
+			}
+		})
+	}
+}
+
+func BenchmarkWildcardCached(b *testing.B) {
+	m := mock{}
+	Wildcard(m)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Wildcard(m)
+	}
+}


### PR DESCRIPTION
Hi,

I'm sending this for the sake of giving back upstream, feel free to use it as you wish.

We've created a function to help us use scany more productively on some experiments we're running with regards to:

* Primary: being able to add new fields on a database (if we use `SELECT *` this is not possible)
* Secondary: naming fields explicitly instead of using `*` mean we've greater performance thanks to any gains related to indices, reduced network communication, etc.

By the way,

* I'm not sure if the name Fields() and Wildcard() conveys nicely what it does. You might also want to consider Columns() instead.
* Maybe the caching layer is overkill.

Thanks.