### PR TITLE
Exception for scannable type

### DIFF
--- a/dbscan/dbscan.go
+++ b/dbscan/dbscan.go
@@ -70,14 +70,17 @@ func NewAPI(opts ...APIOption) (*API, error) {
 	}
 	for _, stOpt := range api.scannableTypesOption {
 		st := reflect.TypeOf(stOpt)
+		if st == nil {
+			return nil, errors.Errorf("scany: scannable type must be a pointer, got %T", st)
+		}
 		if st.Kind() != reflect.Ptr {
 			return nil, errors.Errorf("scany: scannable type must be a pointer, got %s: %s",
-				st.String(), st.Kind())
+				st.Kind(), st.String())
 		}
 		st = st.Elem()
 		if st.Kind() != reflect.Interface {
-			return nil, errors.Errorf("scany: scannable type must be an interface, got %s: %s",
-				st.String(), st.Kind())
+			return nil, errors.Errorf("scany: scannable type must be a pointer to an interface, got %s: %s",
+				st.Kind(), st.String())
 		}
 		api.scannableTypesReflect = append(api.scannableTypesReflect, st)
 	}
@@ -119,7 +122,7 @@ func WithFieldNameMapper(mapperFn NameMapperFunc) APIOption {
 //     Scan(...) error
 // }
 // You can pass it to dbscan this way:
-// dbscan.WithScannableTypes((*Scanner)(nil))
+// dbscan.WithScannableTypes((*Scanner)(nil)).
 func WithScannableTypes(scannableTypes ...interface{}) APIOption {
 	return func(api *API) {
 		api.scannableTypesOption = scannableTypes

--- a/dbscan/dbscan.go
+++ b/dbscan/dbscan.go
@@ -300,5 +300,13 @@ func parseDestination(dst interface{}) (reflect.Value, error) {
 	return dstVal, nil
 }
 
+func mustNewAPI(opts ...APIOption) *API {
+	api, err := NewAPI(opts...)
+	if err != nil {
+		panic(err)
+	}
+	return api
+}
+
 // DefaultAPI is the default instance of API with all configuration settings set to default.
-var DefaultAPI, _ = NewAPI()
+var DefaultAPI = mustNewAPI()

--- a/dbscan/example_test.go
+++ b/dbscan/example_test.go
@@ -96,10 +96,13 @@ func ExampleAPI() {
 	}
 
 	// Instantiate a custom API with overridden settings.
-	api := dbscan.NewAPI(
+	api, err := dbscan.NewAPI(
 		dbscan.WithFieldNameMapper(strings.ToLower),
 		dbscan.WithStructTagKey("database"),
 	)
+	if err != nil {
+		// Handle API initialization error.
+	}
 
 	// Query rows from the database that implement Rows interface.
 	// You should also take care of handling rows error after iteration and closing them.

--- a/dbscan/helpers_test.go
+++ b/dbscan/helpers_test.go
@@ -1,9 +1,11 @@
 package dbscan_test
 
 import (
+	"database/sql"
 	"reflect"
 	"testing"
 
+	"github.com/jackc/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -38,8 +40,14 @@ func queryRows(t *testing.T, query string) dbscan.Rows {
 	return rows
 }
 
-func getAPI() *dbscan.API {
-	return dbscan.NewAPI()
+func getAPI() (*dbscan.API, error) {
+	return dbscan.NewAPI(
+		dbscan.WithScannableTypes(
+			(*sql.Scanner)(nil),
+			(*pgtype.TextDecoder)(nil),
+			(*pgtype.BinaryDecoder)(nil),
+		),
+	)
 }
 
 func scan(t *testing.T, dst interface{}, rows dbscan.Rows) error {

--- a/dbscan/internal_test.go
+++ b/dbscan/internal_test.go
@@ -26,6 +26,7 @@ func DoTestRowScannerStartCalledExactlyOnce(t *testing.T, api *API, queryRows qu
 		rs := args.Get(0).(*RowScanner)
 		rs.columns = []string{"foo", "bar"}
 		rs.columnToFieldIndex = map[string][]int{"foo": {0}, "bar": {1}}
+		rs.scanFn = rs.scanStruct
 	})
 
 	for rows.Next() {

--- a/pgxscan/example_test.go
+++ b/pgxscan/example_test.go
@@ -147,14 +147,17 @@ func ExampleAPI() {
 	}
 
 	// Instantiate a custom API with overridden settings.
-	dbscanAPI, err := dbscan.NewAPI(
+	dbscanAPI, err := pgxscan.NewDBScanAPI(
 		dbscan.WithFieldNameMapper(strings.ToLower),
 		dbscan.WithStructTagKey("database"),
 	)
 	if err != nil {
 		// Handle dbscan API initialization error.
 	}
-	api := pgxscan.NewAPI(dbscanAPI)
+	api, err := pgxscan.NewAPI(dbscanAPI)
+	if err != nil {
+		// Handle pgxscan API initialization error.
+	}
 
 	db, _ := pgxpool.Connect(ctx, "example-connection-url")
 

--- a/pgxscan/example_test.go
+++ b/pgxscan/example_test.go
@@ -147,10 +147,14 @@ func ExampleAPI() {
 	}
 
 	// Instantiate a custom API with overridden settings.
-	api := pgxscan.NewAPI(dbscan.NewAPI(
+	dbscanAPI, err := dbscan.NewAPI(
 		dbscan.WithFieldNameMapper(strings.ToLower),
 		dbscan.WithStructTagKey("database"),
-	))
+	)
+	if err != nil {
+		// Handle dbscan API initialization error.
+	}
+	api := pgxscan.NewAPI(dbscanAPI)
 
 	db, _ := pgxpool.Connect(ctx, "example-connection-url")
 

--- a/pgxscan/pgxscan.go
+++ b/pgxscan/pgxscan.go
@@ -66,6 +66,7 @@ func ScanRow(dst interface{}, rows pgx.Rows) error {
 	return DefaultAPI.ScanRow(dst, rows)
 }
 
+// NewDBScanAPI creates a new dbscan API object with default configuration settings for pgxscan.
 func NewDBScanAPI(opts ...dbscan.APIOption) (*dbscan.API, error) {
 	defaultOpts := []dbscan.APIOption{
 		dbscan.WithScannableTypes(
@@ -192,5 +193,5 @@ func mustNewAPI(dbscanAPI *dbscan.API) *API {
 	return api
 }
 
-// DefaultAPI is the default instance of API that is wrapped around the dbscan.DefaultAPI instance.
+// DefaultAPI is the default instance of API with all configuration settings set to default.
 var DefaultAPI = mustNewAPI(mustNewDBScanAPI())

--- a/pgxscan/pgxscan.go
+++ b/pgxscan/pgxscan.go
@@ -2,7 +2,9 @@ package pgxscan
 
 import (
 	"context"
+	"database/sql"
 
+	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
@@ -64,6 +66,19 @@ func ScanRow(dst interface{}, rows pgx.Rows) error {
 	return DefaultAPI.ScanRow(dst, rows)
 }
 
+func NewDBScanAPI(opts ...dbscan.APIOption) (*dbscan.API, error) {
+	defaultOpts := []dbscan.APIOption{
+		dbscan.WithScannableTypes(
+			(*sql.Scanner)(nil),
+			(*pgtype.BinaryDecoder)(nil),
+			(*pgtype.TextDecoder)(nil),
+		),
+	}
+	opts = append(defaultOpts, opts...)
+	api, err := dbscan.NewAPI(opts...)
+	return api, errors.WithStack(err)
+}
+
 // API is a wrapper around the dbscan.API type.
 // See dbscan.API for details.
 type API struct {
@@ -71,9 +86,9 @@ type API struct {
 }
 
 // NewAPI creates new API instance from dbscan.API instance.
-func NewAPI(dbscanAPI *dbscan.API) *API {
+func NewAPI(dbscanAPI *dbscan.API) (*API, error) {
 	api := &API{dbscanAPI: dbscanAPI}
-	return api
+	return api, nil
 }
 
 // Select is a high-level function that queries rows from Querier and calls the ScanAll function.
@@ -161,5 +176,21 @@ func (ra RowsAdapter) Close() error {
 	return nil
 }
 
+func mustNewDBScanAPI(opts ...dbscan.APIOption) *dbscan.API {
+	api, err := NewDBScanAPI(opts...)
+	if err != nil {
+		panic(err)
+	}
+	return api
+}
+
+func mustNewAPI(dbscanAPI *dbscan.API) *API {
+	api, err := NewAPI(dbscanAPI)
+	if err != nil {
+		panic(err)
+	}
+	return api
+}
+
 // DefaultAPI is the default instance of API that is wrapped around the dbscan.DefaultAPI instance.
-var DefaultAPI = NewAPI(dbscan.DefaultAPI)
+var DefaultAPI = mustNewAPI(mustNewDBScanAPI())

--- a/pgxscan/pgxscan_test.go
+++ b/pgxscan/pgxscan_test.go
@@ -217,8 +217,12 @@ func TestScanRow(t *testing.T) {
 	assert.Equal(t, expected, got)
 }
 
-func getAPI() *pgxscan.API {
-	return pgxscan.NewAPI(dbscan.NewAPI())
+func getAPI() (*pgxscan.API, error) {
+	dbscanAPI, err := dbscan.NewAPI()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return pgxscan.NewAPI(dbscanAPI), nil
 }
 
 func TestMain(m *testing.M) {
@@ -234,7 +238,10 @@ func TestMain(m *testing.M) {
 			panic(err)
 		}
 		defer testDB.Close()
-		testAPI = getAPI()
+		testAPI, err = getAPI()
+		if err != nil {
+			panic(err)
+		}
 		return m.Run()
 	}()
 	os.Exit(exitCode)

--- a/pgxscan/pgxscan_test.go
+++ b/pgxscan/pgxscan_test.go
@@ -222,7 +222,11 @@ func getAPI() (*pgxscan.API, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	return pgxscan.NewAPI(dbscanAPI), nil
+	api, err := pgxscan.NewAPI(dbscanAPI)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return api, nil
 }
 
 func TestMain(m *testing.M) {

--- a/pgxscan/pgxscan_test.go
+++ b/pgxscan/pgxscan_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/georgysavva/scany/dbscan"
-
 	"github.com/georgysavva/scany/pgxscan"
 )
 
@@ -218,7 +216,7 @@ func TestScanRow(t *testing.T) {
 }
 
 func getAPI() (*pgxscan.API, error) {
-	dbscanAPI, err := dbscan.NewAPI()
+	dbscanAPI, err := pgxscan.NewDBScanAPI()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/sqlscan/example_test.go
+++ b/sqlscan/example_test.go
@@ -145,14 +145,17 @@ func ExampleAPI() {
 	}
 
 	// Instantiate a custom API with overridden settings.
-	dbscanAPI, err := dbscan.NewAPI(
+	dbscanAPI, err := sqlscan.NewDBScanAPI(
 		dbscan.WithFieldNameMapper(strings.ToLower),
 		dbscan.WithStructTagKey("database"),
 	)
 	if err != nil {
 		// Handle dbscan API initialization error.
 	}
-	api := sqlscan.NewAPI(dbscanAPI)
+	api, err := sqlscan.NewAPI(dbscanAPI)
+	if err != nil {
+		// Handle sqlscan API initialization error.
+	}
 
 	db, _ := sql.Open("postgres", "example-connection-url")
 

--- a/sqlscan/example_test.go
+++ b/sqlscan/example_test.go
@@ -145,10 +145,14 @@ func ExampleAPI() {
 	}
 
 	// Instantiate a custom API with overridden settings.
-	api := sqlscan.NewAPI(dbscan.NewAPI(
+	dbscanAPI, err := dbscan.NewAPI(
 		dbscan.WithFieldNameMapper(strings.ToLower),
 		dbscan.WithStructTagKey("database"),
-	))
+	)
+	if err != nil {
+		// Handle dbscan API initialization error.
+	}
+	api := sqlscan.NewAPI(dbscanAPI)
 
 	db, _ := sql.Open("postgres", "example-connection-url")
 

--- a/sqlscan/sqlscan.go
+++ b/sqlscan/sqlscan.go
@@ -63,6 +63,7 @@ func ScanRow(dst interface{}, rows *sql.Rows) error {
 	return DefaultAPI.ScanRow(dst, rows)
 }
 
+// NewDBScanAPI creates a new dbscan API object with default configuration settings for sqlscan.
 func NewDBScanAPI(opts ...dbscan.APIOption) (*dbscan.API, error) {
 	defaultOpts := []dbscan.APIOption{
 		dbscan.WithScannableTypes(
@@ -160,5 +161,5 @@ func mustNewAPI(dbscanAPI *dbscan.API) *API {
 	return api
 }
 
-// DefaultAPI is the default instance of API that is wrapped around the dbscan.DefaultAPI instance.
+// DefaultAPI is the default instance of API with all configuration settings set to default.
 var DefaultAPI = mustNewAPI(mustNewDBScanAPI())

--- a/sqlscan/sqlscan.go
+++ b/sqlscan/sqlscan.go
@@ -63,6 +63,17 @@ func ScanRow(dst interface{}, rows *sql.Rows) error {
 	return DefaultAPI.ScanRow(dst, rows)
 }
 
+func NewDBScanAPI(opts ...dbscan.APIOption) (*dbscan.API, error) {
+	defaultOpts := []dbscan.APIOption{
+		dbscan.WithScannableTypes(
+			(*sql.Scanner)(nil),
+		),
+	}
+	opts = append(defaultOpts, opts...)
+	api, err := dbscan.NewAPI(opts...)
+	return api, errors.WithStack(err)
+}
+
 // API is a wrapper around the dbscan.API type.
 // See dbscan.API for details.
 type API struct {
@@ -70,9 +81,9 @@ type API struct {
 }
 
 // NewAPI creates new API instance from dbscan.API instance.
-func NewAPI(dbscanAPI *dbscan.API) *API {
+func NewAPI(dbscanAPI *dbscan.API) (*API, error) {
 	api := &API{dbscanAPI: dbscanAPI}
-	return api
+	return api, nil
 }
 
 // Select is a high-level function that queries rows from Querier and calls the ScanAll function.
@@ -133,5 +144,21 @@ func (api *API) ScanRow(dst interface{}, rows *sql.Rows) error {
 	return errors.WithStack(err)
 }
 
+func mustNewDBScanAPI(opts ...dbscan.APIOption) *dbscan.API {
+	api, err := NewDBScanAPI(opts...)
+	if err != nil {
+		panic(err)
+	}
+	return api
+}
+
+func mustNewAPI(dbscanAPI *dbscan.API) *API {
+	api, err := NewAPI(dbscanAPI)
+	if err != nil {
+		panic(err)
+	}
+	return api
+}
+
 // DefaultAPI is the default instance of API that is wrapped around the dbscan.DefaultAPI instance.
-var DefaultAPI = NewAPI(dbscan.DefaultAPI)
+var DefaultAPI = mustNewAPI(mustNewDBScanAPI())

--- a/sqlscan/sqlscan_test.go
+++ b/sqlscan/sqlscan_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/georgysavva/scany/dbscan"
-
 	"github.com/georgysavva/scany/sqlscan"
 )
 
@@ -253,7 +251,7 @@ func requireNoRowsErrorsAndClose(t *testing.T, rows *sql.Rows) {
 }
 
 func getAPI() (*sqlscan.API, error) {
-	dbscanAPI, err := dbscan.NewAPI()
+	dbscanAPI, err := sqlscan.NewDBScanAPI()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/sqlscan/sqlscan_test.go
+++ b/sqlscan/sqlscan_test.go
@@ -275,8 +275,8 @@ func TestMain(m *testing.M) {
 			panic(err)
 		}
 		defer func() {
-			if err := testDB.Close(); err != nil {
-				panic(err)
+			if closeErr := testDB.Close(); closeErr != nil {
+				panic(closeErr)
 			}
 		}()
 		testAPI, err = getAPI()

--- a/sqlscan/sqlscan_test.go
+++ b/sqlscan/sqlscan_test.go
@@ -257,7 +257,11 @@ func getAPI() (*sqlscan.API, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	return sqlscan.NewAPI(dbscanAPI), nil
+	api, err := sqlscan.NewAPI(dbscanAPI)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return api, nil
 }
 
 func TestMain(m *testing.M) {

--- a/sqlscan/sqlscan_test.go
+++ b/sqlscan/sqlscan_test.go
@@ -252,8 +252,12 @@ func requireNoRowsErrorsAndClose(t *testing.T, rows *sql.Rows) {
 	require.NoError(t, rows.Close())
 }
 
-func getAPI() *sqlscan.API {
-	return sqlscan.NewAPI(dbscan.NewAPI())
+func getAPI() (*sqlscan.API, error) {
+	dbscanAPI, err := dbscan.NewAPI()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return sqlscan.NewAPI(dbscanAPI), nil
 }
 
 func TestMain(m *testing.M) {
@@ -273,7 +277,10 @@ func TestMain(m *testing.M) {
 				panic(err)
 			}
 		}()
-		testAPI = getAPI()
+		testAPI, err = getAPI()
+		if err != nil {
+			panic(err)
+		}
 		return m.Run()
 	}()
 	os.Exit(exitCode)


### PR DESCRIPTION
This PR adds an exception for scannable types to be treated as primitive types rather than structs or maps.
Fixes: https://github.com/georgysavva/scany/issues/63, https://github.com/georgysavva/scany/issues/33, https://github.com/georgysavva/scany/issues/73.