### PR TITLE
Fix ScanAll() for scannable types

### DIFF
--- a/dbscan/dbscan_test.go
+++ b/dbscan/dbscan_test.go
@@ -103,6 +103,48 @@ func TestScanAll(t *testing.T) {
 			},
 		},
 		{
+			name: "slice of CustomScannableType",
+			query: `
+				SELECT *
+				FROM (
+					VALUES ('{"key1": "foo val 1", "key2": "bar val 1"}'), 
+                           ('{"key1": "foo val 2", "key2": "bar val 2"}')
+				) AS t (foo)
+			`,
+			expected: []CustomScannableType{
+				{Key1: "foo val 1", Key2: "bar val 1"},
+				{Key1: "foo val 2", Key2: "bar val 2"},
+			},
+		},
+		{
+			name: "slice of *CustomScannableType",
+			query: `
+				SELECT *
+				FROM (
+					VALUES ('{"key1": "foo val 1", "key2": "bar val 1"}'::JSON), 
+                           ('{"key1": "foo val 2", "key2": "bar val 2"}'::JSON)
+				) AS t (foo)
+			`,
+			expected: []*CustomScannableType{
+				{Key1: "foo val 1", Key2: "bar val 1"},
+				{Key1: "foo val 2", Key2: "bar val 2"},
+			},
+		},
+		{
+			name: "slice of *CustomScannableType NULL",
+			query: `
+				SELECT *
+				FROM (
+					VALUES (NULL::JSON), 
+                           (NULL::JSON)
+				) AS t (foo)
+			`,
+			expected: []*CustomScannableType{
+				nil,
+				nil,
+			},
+		},
+		{
 			name: "slice of strings by ptr",
 			query: `
 				SELECT *

--- a/dbscan/rowscanner.go
+++ b/dbscan/rowscanner.go
@@ -85,28 +85,27 @@ func startScanner(rs *RowScanner, dstValue reflect.Value) error {
 		return errors.WithStack(err)
 	}
 	dstKind := dstValue.Kind()
-
-	isScannable := rs.api.isScannableType(dstValue)
+	dstType:=dstValue.Type()
+	isScannable := rs.api.isScannableType(dstType)
 	if isScannable && len(rs.columns) == 1 {
 		rs.scanFn = rs.scanPrimitive
 		return nil
 	}
 
 	if dstKind == reflect.Struct {
-		rs.columnToFieldIndex = rs.api.getColumnToFieldIndexMap(dstValue.Type())
+		rs.columnToFieldIndex = rs.api.getColumnToFieldIndexMap(dstType)
 		rs.scanFn = rs.scanStruct
 		return nil
 	}
 
 	if dstKind == reflect.Map {
-		mapType := dstValue.Type()
-		if mapType.Key().Kind() != reflect.String {
+		if dstType.Key().Kind() != reflect.String {
 			return errors.Errorf(
 				"scany: invalid type %v: map must have string key, got: %v",
-				mapType, mapType.Key(),
+				dstType, dstType.Key(),
 			)
 		}
-		rs.mapElementType = mapType.Elem()
+		rs.mapElementType = dstType.Elem()
 		rs.scanFn = rs.scanMap
 		return nil
 	}

--- a/dbscan/rowscanner.go
+++ b/dbscan/rowscanner.go
@@ -85,7 +85,7 @@ func startScanner(rs *RowScanner, dstValue reflect.Value) error {
 		return errors.WithStack(err)
 	}
 	dstKind := dstValue.Kind()
-	dstType:=dstValue.Type()
+	dstType := dstValue.Type()
 	isScannable := rs.api.isScannableType(dstType)
 	if isScannable && len(rs.columns) == 1 {
 		rs.scanFn = rs.scanPrimitive

--- a/dbscan/rowscanner_test.go
+++ b/dbscan/rowscanner_test.go
@@ -70,11 +70,9 @@ type CustomScannableType struct {
 func (cst *CustomScannableType) Scan(val interface{}) error {
 	switch v := val.(type) {
 	case []byte:
-		json.Unmarshal(v, cst)
-		return nil
+		return json.Unmarshal(v, cst)
 	case string:
-		json.Unmarshal([]byte(v), cst)
-		return nil
+		return json.Unmarshal([]byte(v), cst)
 	default:
 		return errors.New(fmt.Sprintf("Unsupported type: %T", v))
 	}

--- a/dbscan/rowscanner_test.go
+++ b/dbscan/rowscanner_test.go
@@ -1,10 +1,13 @@
 package dbscan_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgtype"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -57,6 +60,24 @@ type AmbiguousNested1 struct {
 
 type AmbiguousNested2 struct {
 	Foo string
+}
+
+type CustomScannableType struct {
+	Key1 string
+	Key2 string
+}
+
+func (cst *CustomScannableType) Scan(val interface{}) error {
+	switch v := val.(type) {
+	case []byte:
+		json.Unmarshal(v, cst)
+		return nil
+	case string:
+		json.Unmarshal([]byte(v), cst)
+		return nil
+	default:
+		return errors.New(fmt.Sprintf("Unsupported type: %T", v))
+	}
 }
 
 func TestRowScanner_Scan_structDestination(t *testing.T) {
@@ -748,6 +769,13 @@ func TestRowScanner_Scan_primitiveTypeDestination(t *testing.T) {
 			expected: makeStrPtr("foo val"),
 		},
 		{
+			name: "string by ptr NULL value",
+			query: `
+				SELECT NULL AS foo 
+			`,
+			expected: (*string)(nil),
+		},
+		{
 			name: "slice",
 			query: `
 				SELECT ARRAY('foo val', 'foo val 2', 'foo val 3') AS foo 
@@ -842,11 +870,32 @@ func TestRowScanner_Scan_ScannableTypeDestination(t *testing.T) {
 		expected       interface{}
 	}{
 		{
-			name: "pgtype.Text destination type and pgtype.TextDecoder scannable type",
+			name: "pgtype.Text destination type",
 			query: `
 				SELECT 'foo val' AS foo 
 			`,
 			expected: pgtype.Text{String: "foo val", Status: pgtype.Present},
+		},
+		{
+			name: "CustomScannableType destination type",
+			query: `
+				SELECT '{"key1": "foo val", "key2": "bar val"}'::JSON AS foo 
+			`,
+			expected: CustomScannableType{Key1: "foo val", Key2: "bar val"},
+		},
+		{
+			name: "*CustomScannableType destination type",
+			query: `
+				SELECT '{"key1": "foo val", "key2": "bar val"}'::JSON AS foo 
+			`,
+			expected: &CustomScannableType{Key1: "foo val", Key2: "bar val"},
+		},
+		{
+			name: "*CustomScannableType destination type NULL value",
+			query: `
+				SELECT NULL::JSON AS foo 
+			`,
+			expected: (*CustomScannableType)(nil),
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Add exception for scannable types when not taking the second pointer of structs in ScanAll().