### PR TITLE
Add special type for scanning of unused columns (V1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,5 +55,4 @@ jobs:
           env_vars: GO
           name: codecov-umbrella
           fail_ci_if_error: true
-          path_to_write_report: ./codecov_report.txt
           verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
       - name: Download CockroachDB Binary
         run: |
-          wget -qO- https://binaries.cockroachdb.com/cockroach-v20.1.3.linux-amd64.tgz | tar  xvz
-          sudo cp -i cockroach-v20.1.3.linux-amd64/cockroach /usr/local/bin/
+          wget -qO- https://binaries.cockroachdb.com/cockroach-v23.2.3.linux-amd64.tgz | tar  xvz
+          sudo cp -i cockroach-v23.2.3.linux-amd64/cockroach /usr/local/bin/
 
       - name: Install Go
         uses: actions/setup-go@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,8 +48,9 @@ jobs:
         run: go test -v -race  -coverprofile=coverage.txt -covermode=atomic ./... --cockroach-binary cockroach
 
       - name: Upload Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.txt
           flags: unittests
           env_vars: GO

--- a/dbscan/dbscan_test.go
+++ b/dbscan/dbscan_test.go
@@ -406,7 +406,10 @@ func TestMain(m *testing.M) {
 			panic(err)
 		}
 		defer testDB.Close()
-		prepareTestDB(testDB)
+		err = prepareTestDB(testDB)
+		if err != nil {
+			panic(err)
+		}
 		testAPI, err = getAPI()
 		if err != nil {
 			panic(err)
@@ -417,9 +420,9 @@ func TestMain(m *testing.M) {
 }
 
 func prepareTestDB(testDB *pgxpool.Pool) (err error) {
-	_, err = testDB.Query(ctx, `
+	_, err = testDB.Exec(ctx, `
 		CREATE TYPE test_enum_type AS ENUM ('test_val_1', 'test_val_2');
 	`)
 
-	return
+	return err
 }

--- a/dbscan/rowscanner.go
+++ b/dbscan/rowscanner.go
@@ -1,6 +1,7 @@
 package dbscan
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"reflect"
 )
@@ -123,13 +124,23 @@ func startScanner(rs *RowScanner, dstValue reflect.Value) error {
 	)
 }
 
+type noOpScanType struct{}
+
+func (*noOpScanType) Scan(value interface{}) error {
+	return nil
+}
+
+func (noOpScanType) Value() (driver.Value, error) {
+	return nil, nil
+}
+
 func (rs *RowScanner) scanStruct(structValue reflect.Value) error {
 	scans := make([]interface{}, len(rs.columns))
 	for i, column := range rs.columns {
 		fieldIndex, ok := rs.columnToFieldIndex[column]
 		if !ok {
 			if rs.api.allowUnknownColumns {
-				var tmp interface{}
+				var tmp noOpScanType
 				scans[i] = &tmp
 				continue
 			}

--- a/dbscan/rowscanner.go
+++ b/dbscan/rowscanner.go
@@ -1,7 +1,6 @@
 package dbscan
 
 import (
-	"database/sql/driver"
 	"fmt"
 	"reflect"
 )
@@ -128,10 +127,6 @@ type noOpScanType struct{}
 
 func (*noOpScanType) Scan(value interface{}) error {
 	return nil
-}
-
-func (noOpScanType) Value() (driver.Value, error) {
-	return nil, nil
 }
 
 func (rs *RowScanner) scanStruct(structValue reflect.Value) error {


### PR DESCRIPTION
**The problem**: at my job when we worked with custom enums there was a problem when a new custom enum wasn't yet added to a struct for scanning. It leaded to an error when `SELECT * FROM ...` was used:

```
scany: scan row into struct fields: can't scan into dest[<idx>]: unknown oid <oid> cannot be scanned into *interface {}
```

This problem occurs because the `interface{}` type obviously doesn't implement the `sql.Scanner` interface. So, I added a new type that does the job and replaced the `interface{}` that was used for scanning of columns which wouldn't be used.